### PR TITLE
Opsera Hummingbird AI: Converted Bamboo plan TEST-TEST to GHA

### DIFF
--- a/.github/workflows/TEST-TEST.yml
+++ b/.github/workflows/TEST-TEST.yml
@@ -1,0 +1,25 @@
+name: Test Workflow
+
+on:
+  push:
+    branches:
+      - main
+      - test
+  schedule:
+    - cron: '*/3 * * * *' # Equivalent to Bamboo polling every 180 seconds
+
+jobs:
+  spring:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+  default_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+# Note: Direct translations for branch management, notifications, and Jira linking are not available. These have been omitted.
+# GitHub Actions does not support Bamboo's branch management and Jira linking directly.


### PR DESCRIPTION


pipeline migrated from Bamboo plan [TEST-TEST](https://bamboo.shared-private.opsera.io//browse/TEST-TEST) to GitHub Actions using Opsera Hummingbird AI
---

### Action Items:
- [ ] Add respective GitHub repo secrets if needed.
- [ ] Review manual trigger replacements and ensure the cron schedule matches the intended trigger frequency.
- [ ] Implement branch management and Jira linking through additional scripts or integrations if necessary.
- [ ] Review permissions, as GitHub permissions management is different from Bamboo.
