### PR TITLE
Opsera Hummingbird AI: Converted Bamboo plan MARS-ROCKET to GHA

### DIFF
--- a/.github/workflows/MARS-ROCKET.yml
+++ b/.github/workflows/MARS-ROCKET.yml
@@ -1,0 +1,81 @@
+name: Build the Rocket
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '*/60 * * * *'  # Equivalent to Bamboo polling trigger
+
+jobs:
+  build-and-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Equivalent to Bamboo fetch-all
+      - name: Build Scripts
+        run: pwsh bootstrap.ps1
+    env:
+      BLACKDUCK_HUB_HOST: ${{ secrets.BLACKDUCK_HUB_HOST }}
+      BLACKDUCK_HUB_PROJECT_ID: ${{ secrets.BLACKDUCK_HUB_PROJECT_ID }}
+      BLACKDUCK_HUB_PROJECT_NAME: ${{ secrets.BLACKDUCK_HUB_PROJECT_NAME }}
+      BLACKDUCK_HUB_USERNAME: ${{ secrets.BLACKDUCK_HUB_USERNAME }}
+      DOCKER_ARTIFACTORY_SOURCEURL_STABLE: ${{ secrets.DOCKER_ARTIFACTORY_SOURCEURL_STABLE }}
+      DOCKER_ARTIFACTORY_SOURCEURL_UNSTABLE: ${{ secrets.DOCKER_ARTIFACTORY_SOURCEURL_UNSTABLE }}
+      DOCKER_DEPLOY_USER: ${{ secrets.DOCKER_DEPLOY_USER }}
+      DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      GENERIC_REPORTS_SOURCEURL_STABLE: ${{ secrets.GENERIC_REPORTS_SOURCEURL_STABLE }}
+      GENERIC_REPORTS_SOURCEURL_UNSTABLE: ${{ secrets.GENERIC_REPORTS_SOURCEURL_UNSTABLE }}
+      NUGET_DEPLOY_SOURCEURL_STABLE: ${{ secrets.NUGET_DEPLOY_SOURCEURL_STABLE }}
+      NUGET_DEPLOY_SOURCEURL_UNSTABLE: ${{ secrets.NUGET_DEPLOY_SOURCEURL_UNSTABLE }}
+      OCTOPUS_PROJECTNAME: ${{ secrets.OCTOPUS_PROJECTNAME }}
+      OCTOPUS_SERVER: ${{ secrets.OCTOPUS_SERVER }}
+      TWISTLOCK_SAASOPS_ACCESSKEYID: ${{ secrets.TWISTLOCK_SAASOPS_ACCESSKEYID }}
+      TWISTLOCK_SAASOPS_SA_NAME: ${{ secrets.TWISTLOCK_SAASOPS_SA_NAME }}
+      TWISTLOCK_SAASOPS_SERVERURL: ${{ secrets.TWISTLOCK_SAASOPS_SERVERURL }}
+      TWISTLOCK_SERVERPORT: ${{ secrets.TWISTLOCK_SERVERPORT }}
+      TWISTLOCK_SERVERURL: ${{ secrets.TWISTLOCK_SERVERURL }}
+      TWISTLOCK_USERNAME: ${{ secrets.TWISTLOCK_USERNAME }}
+
+  run-quality-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run Quality Tools
+        run: pwsh bootstrap.ps1 -Target Quality
+
+  run-oss-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run OSS Scan
+        run: pwsh bootstrap.ps1 -Target OpenSourceSoftwareScan
+
+  run-security-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run Security Tools
+        run: pwsh bootstrap.ps1 -Target Security
+
+  publish-artifacts:
+    runs-on: ubuntu-latest
+    needs: build-and-package
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Publish Packages
+        run: pwsh bootstrap.ps1 -Target Publish


### PR DESCRIPTION


pipeline migrated from Bamboo plan [MARS-ROCKET](https://bamboo.shared-private.opsera.io//browse/MARS-ROCKET) to GitHub Actions using Opsera Hummingbird AI
---

### Action Items:
- [ ] Add respective GitHub secrets for sensitive information like BLACKDUCK_HUB_HOST and others.
- [ ] Verify manual trigger conversions.
- [ ] For features not supported by GitHub Actions, such as Bamboo's concurrent build plugin, consider if any alternative setup is needed.
- [ ] Review webhook notifications and set up in GitHub if necessary, as GitHub Actions does not natively support webhook notifications as Bamboo does.
